### PR TITLE
upgrade orchestrate version and heml chart versions

### DIFF
--- a/helmfile-core.yaml
+++ b/helmfile-core.yaml
@@ -7,7 +7,7 @@ releases:
     namespace: {{ requiredEnv "TARGET_NAMESPACE" }}
     chart: helm-pegasys/core-stack-worker
     atomic: true
-    version: 0.5.2
+    version: 0.5.3
     values:
       - values/common.yaml.gotmpl
       - values/common-worker.yaml.gotmpl
@@ -17,7 +17,7 @@ releases:
     namespace: {{ requiredEnv "TARGET_NAMESPACE" }}
     chart: helm-pegasys/core-stack-worker
     atomic: true
-    version: 0.5.2
+    version: 0.5.3
     values:
       - values/common.yaml.gotmpl
       - values/common-worker.yaml.gotmpl
@@ -27,7 +27,7 @@ releases:
     namespace: {{ requiredEnv "TARGET_NAMESPACE" }}
     chart: helm-pegasys/core-stack-worker
     atomic: true
-    version: 0.5.2
+    version: 0.5.3
     values:
       - values/common.yaml.gotmpl
       - values/common-worker.yaml.gotmpl
@@ -37,7 +37,7 @@ releases:
     namespace: {{ requiredEnv "TARGET_NAMESPACE" }}
     chart: helm-pegasys/core-stack-worker
     atomic: true
-    version: 0.5.2
+    version: 0.5.3
     values:
       - values/common.yaml.gotmpl
       - values/common-worker.yaml.gotmpl
@@ -47,7 +47,7 @@ releases:
     namespace: {{ requiredEnv "TARGET_NAMESPACE" }}
     chart: helm-pegasys/core-stack-api
     atomic: true
-    version: 0.5.4
+    version: 0.5.6
     values:
       - values/common.yaml.gotmpl
       - values/common-api.yaml.gotmpl
@@ -57,7 +57,7 @@ releases:
     namespace: {{ requiredEnv "TARGET_NAMESPACE" }}
     chart: helm-pegasys/core-stack-api
     atomic: true
-    version: 0.5.4
+    version: 0.5.6
     values:
       - values/common.yaml.gotmpl
       - values/common-api.yaml.gotmpl
@@ -67,7 +67,7 @@ releases:
     namespace: {{ requiredEnv "TARGET_NAMESPACE" }}
     chart: helm-pegasys/core-stack-api
     atomic: true
-    version: 0.5.4
+    version: 0.5.6
     values:
       - values/common.yaml.gotmpl
       - values/common-api.yaml.gotmpl

--- a/values/tags.yaml
+++ b/values/tags.yaml
@@ -1,7 +1,7 @@
 ---
 tags:
-  orchestrate: v2.3.0-rc2
-  e2e: v2.3.0-rc2
+  orchestrate: v2.3.0
+  e2e: v2.3.0
 
 repositories:
   orchestrate: consensys-docker-pegasys-orchestrate.bintray.io/orchestrate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines -->

## PR Description

## Fixed Issue(s)

- Update orchestrate image to latest stable version v2.3.0
- Update helm chart version to 0.5.3 (core-stack-worker) and 0.5.6 (core-stack-api)
